### PR TITLE
Moving partial points page in ToC

### DIFF
--- a/source/instructors/authoring/assessments/add-assessment.rst
+++ b/source/instructors/authoring/assessments/add-assessment.rst
@@ -13,13 +13,13 @@ Auto-graded assessments
    assessments
    student-submission
    auto-grade-scripts
-   partial-points
    parameterized
    delete-assessment
    edit-assessment
    edit-assessment-points
    standard-code-test
    advanced-code-test
+   partial-points
    multiple-choice
    fill-in-blanks
    free-text


### PR DESCRIPTION
Moving partial points so it is correctly associated with Advanced Code Tests and not Assignment-level auto-grade scripts